### PR TITLE
配合asr需要cudnn，ta̍k-ke攏用kāng-khuán--ê。

### DIFF
--- a/asr/Dockerfile
+++ b/asr/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/mt/Dockerfile
+++ b/mt/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/tts/Dockerfile
+++ b/tts/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \


### PR DESCRIPTION
## PR描述

PR類型：Bug
Issue連結： 無
為什麼要有這支PR：因為 #73 hōo asr, tts, mt公家base image kah apt套件，省build時間kah硬碟空間，毋過無考慮tio̍h asr需要cudnn，所以ta̍k-ke攏用 cudnn base image。
值得提出或注意的技術細節：無

這ê問題ài用GPU走才會發生，tī local走bē發生

## 變更影響

無

## 本底錯誤畫面

<img width="1812" height="1034" alt="圖片" src="https://github.com/user-attachments/assets/879ecd0d-e1e6-4036-88f8-a3b777a69d8f" />

